### PR TITLE
Migrated to eBGP-only Design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Clab Backup Files
+*.clab.yml.bak
+
+# Clab Artifacts
+clab-evpn-clos2/

--- a/configs/leaf1.cfg
+++ b/configs/leaf1.cfg
@@ -37,33 +37,36 @@ set / network-instance default interface ethernet-1/8.0
 set / network-instance default interface ethernet-1/9.0
 set / network-instance default interface system0.0
 
-# routing policy
-set / routing-policy policy all default-action
-set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols bgp autonomous-system 65101
 set / network-instance default protocols bgp router-id 10.0.250.11
+set / network-instance default protocols bgp ebgp-default-policy import-reject-all true
+set / network-instance default protocols bgp ebgp-default-policy export-reject-all true
+set / network-instance default protocols bgp afi-safi evpn admin-state enable
+set / network-instance default protocols bgp afi-safi evpn multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi evpn multipath ebgp maximum-paths 64
+set / network-instance default protocols bgp afi-safi evpn evpn inter-as-vpn true
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath ebgp maximum-paths 2
+set / network-instance default protocols bgp afi-safi ipv4-unicast evpn rapid-update true
+set / network-instance default protocols bgp preference ebgp 170
+set / network-instance default protocols bgp preference ibgp 170
+set / network-instance default protocols bgp route-advertisement rapid-withdrawal true
+set / network-instance default protocols bgp route-advertisement wait-for-fib-install false
 
-# eBGP-underlay group
-set / network-instance default protocols bgp group eBGP-underlay export-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay import-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay peer-as 65201
-set / network-instance default protocols bgp neighbor 10.0.1.0 peer-group eBGP-underlay
-set / network-instance default protocols bgp neighbor 10.0.2.0 peer-group eBGP-underlay
-
-# iBGP-overlay group
-set / network-instance default protocols bgp group iBGP-overlay export-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay import-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay peer-as 65100
-set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay local-as as-number 65100
-set / network-instance default protocols bgp neighbor 10.0.250.1 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.1 transport local-address 10.0.250.11
-set / network-instance default protocols bgp neighbor 10.0.250.2 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.2 transport local-address 10.0.250.11
+# eBGP group
+set / network-instance default protocols bgp group eBGP-peers admin-state enable
+set / network-instance default protocols bgp group eBGP-peers export-policy [ ebgp-isl-export-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers import-policy [ ebgp-isl-import-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers failure-detection fast-failover true
+set / network-instance default protocols bgp group eBGP-peers afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group eBGP-peers afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp group eBGP-peers peer-as 65201
+set / network-instance default protocols bgp neighbor 10.0.1.0 peer-group eBGP-peers
+set / network-instance default protocols bgp neighbor 10.0.2.0 peer-group eBGP-peers
 
 # MAC-VRF
 set / network-instance mac-vrf-1 type mac-vrf
@@ -74,10 +77,67 @@ set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1
 set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 admin-state enable
 set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.1
 set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 evi 111
-set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 ecmp 2
+set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 ecmp 8
+set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 routes bridge-table mac-ip advertise-arp-nd-only-with-mac-table-entry true
 set / network-instance mac-vrf-1 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:111
 set / network-instance mac-vrf-1 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:111
+set / network-instance mac-vrf-1 bridge-table mac-learning admin-state enable
+set / network-instance mac-vrf-1 bridge-table mac-learning aging admin-state enable
+set / network-instance mac-vrf-1 bridge-table mac-learning aging age-time 300
+set / network-instance mac-vrf-1 bridge-table mac-duplication admin-state enable
+set / network-instance mac-vrf-1 bridge-table mac-duplication monitoring-window 3
+set / network-instance mac-vrf-1 bridge-table mac-duplication num-moves 5
+set / network-instance mac-vrf-1 bridge-table mac-duplication hold-down-time 9
+set / network-instance mac-vrf-1 bridge-table mac-duplication action stop-learning
 
 # VXLAN tunnel interface
 set / tunnel-interface vxlan1 vxlan-interface 1 type bridged
 set / tunnel-interface vxlan1 vxlan-interface 1 ingress vni 1
+
+# Routing policies for eBGP
+set / routing-policy prefix-set prefixset-dc1 prefix 10.0.250.0/24 mask-length-range 32..32
+set / routing-policy policy ebgp-isl-export-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match prefix prefix-set prefixset-dc1
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match protocol local
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 match protocol bgp
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 match protocol aggregate
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 match protocol bgp
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action bgp local-preference set 100

--- a/configs/leaf2.cfg
+++ b/configs/leaf2.cfg
@@ -37,33 +37,36 @@ set / network-instance default interface ethernet-1/8.0
 set / network-instance default interface ethernet-1/9.0
 set / network-instance default interface system0.0
 
-# routing policy
-set / routing-policy policy all default-action
-set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols bgp autonomous-system 65102
 set / network-instance default protocols bgp router-id 10.0.250.12
+set / network-instance default protocols bgp ebgp-default-policy import-reject-all true
+set / network-instance default protocols bgp ebgp-default-policy export-reject-all true
+set / network-instance default protocols bgp afi-safi evpn admin-state enable
+set / network-instance default protocols bgp afi-safi evpn multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi evpn multipath ebgp maximum-paths 64
+set / network-instance default protocols bgp afi-safi evpn evpn inter-as-vpn true
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath ebgp maximum-paths 2
+set / network-instance default protocols bgp afi-safi ipv4-unicast evpn rapid-update true
+set / network-instance default protocols bgp preference ebgp 170
+set / network-instance default protocols bgp preference ibgp 170
+set / network-instance default protocols bgp route-advertisement rapid-withdrawal true
+set / network-instance default protocols bgp route-advertisement wait-for-fib-install false
 
-# eBGP-underlay group
-set / network-instance default protocols bgp group eBGP-underlay export-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay import-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay peer-as 65201
-set / network-instance default protocols bgp neighbor 10.0.1.2 peer-group eBGP-underlay
-set / network-instance default protocols bgp neighbor 10.0.2.2 peer-group eBGP-underlay
-
-# iBGP-overlay group
-set / network-instance default protocols bgp group iBGP-overlay export-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay import-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay peer-as 65100
-set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay local-as as-number 65100
-set / network-instance default protocols bgp neighbor 10.0.250.1 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.1 transport local-address 10.0.250.12
-set / network-instance default protocols bgp neighbor 10.0.250.2 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.2 transport local-address 10.0.250.12
+# eBGP group
+set / network-instance default protocols bgp group eBGP-peers admin-state enable
+set / network-instance default protocols bgp group eBGP-peers export-policy [ ebgp-isl-export-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers import-policy [ ebgp-isl-import-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers failure-detection fast-failover true
+set / network-instance default protocols bgp group eBGP-peers afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group eBGP-peers afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp group eBGP-peers peer-as 65201
+set / network-instance default protocols bgp neighbor 10.0.1.2 peer-group eBGP-peers
+set / network-instance default protocols bgp neighbor 10.0.2.2 peer-group eBGP-peers
 
 # MAC-VRF
 set / network-instance mac-vrf-1 type mac-vrf
@@ -74,10 +77,67 @@ set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1
 set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 admin-state enable
 set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.1
 set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 evi 111
-set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 ecmp 2
+set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 ecmp 8
+set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 routes bridge-table mac-ip advertise-arp-nd-only-with-mac-table-entry true
 set / network-instance mac-vrf-1 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:111
 set / network-instance mac-vrf-1 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:111
+set / network-instance mac-vrf-1 bridge-table mac-learning admin-state enable
+set / network-instance mac-vrf-1 bridge-table mac-learning aging admin-state enable
+set / network-instance mac-vrf-1 bridge-table mac-learning aging age-time 300
+set / network-instance mac-vrf-1 bridge-table mac-duplication admin-state enable
+set / network-instance mac-vrf-1 bridge-table mac-duplication monitoring-window 3
+set / network-instance mac-vrf-1 bridge-table mac-duplication num-moves 5
+set / network-instance mac-vrf-1 bridge-table mac-duplication hold-down-time 9
+set / network-instance mac-vrf-1 bridge-table mac-duplication action stop-learning
 
 # VXLAN tunnel interface
 set / tunnel-interface vxlan1 vxlan-interface 1 type bridged
 set / tunnel-interface vxlan1 vxlan-interface 1 ingress vni 1
+
+# Routing policies for eBGP
+set / routing-policy prefix-set prefixset-dc1 prefix 10.0.250.0/24 mask-length-range 32..32
+set / routing-policy policy ebgp-isl-export-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match prefix prefix-set prefixset-dc1
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match protocol local
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 match protocol bgp
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 match protocol aggregate
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 match protocol bgp
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action bgp local-preference set 100

--- a/configs/leaf3.cfg
+++ b/configs/leaf3.cfg
@@ -47,47 +47,59 @@ set / network-instance default interface ethernet-1/8.0
 set / network-instance default interface ethernet-1/9.0
 set / network-instance default interface system0.0
 
-# routing policy
-set / routing-policy policy all default-action
-set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols bgp autonomous-system 65103
 set / network-instance default protocols bgp router-id 10.0.250.13
+set / network-instance default protocols bgp ebgp-default-policy import-reject-all true
+set / network-instance default protocols bgp ebgp-default-policy export-reject-all true
+set / network-instance default protocols bgp afi-safi evpn admin-state enable
+set / network-instance default protocols bgp afi-safi evpn multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi evpn multipath ebgp maximum-paths 64
+set / network-instance default protocols bgp afi-safi evpn evpn inter-as-vpn true
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath ebgp maximum-paths 2
+set / network-instance default protocols bgp afi-safi ipv4-unicast evpn rapid-update true
+set / network-instance default protocols bgp preference ebgp 170
+set / network-instance default protocols bgp preference ibgp 170
+set / network-instance default protocols bgp route-advertisement rapid-withdrawal true
+set / network-instance default protocols bgp route-advertisement wait-for-fib-install false
 
-# eBGP-underlay group
-set / network-instance default protocols bgp group eBGP-underlay export-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay import-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay peer-as 65201
-set / network-instance default protocols bgp neighbor 10.0.1.4 peer-group eBGP-underlay
-set / network-instance default protocols bgp neighbor 10.0.2.4 peer-group eBGP-underlay
-
-# iBGP-overlay group
-set / network-instance default protocols bgp group iBGP-overlay export-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay import-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay peer-as 65100
-set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay local-as as-number 65100
-set / network-instance default protocols bgp neighbor 10.0.250.1 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.1 transport local-address 10.0.250.13
-set / network-instance default protocols bgp neighbor 10.0.250.2 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.2 transport local-address 10.0.250.13
+# eBGP group
+set / network-instance default protocols bgp group eBGP-peers admin-state enable
+set / network-instance default protocols bgp group eBGP-peers export-policy [ ebgp-isl-export-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers import-policy [ ebgp-isl-import-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers failure-detection fast-failover true
+set / network-instance default protocols bgp group eBGP-peers afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group eBGP-peers afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp group eBGP-peers peer-as 65201
+set / network-instance default protocols bgp neighbor 10.0.1.4 peer-group eBGP-peers
+set / network-instance default protocols bgp neighbor 10.0.2.4 peer-group eBGP-peers
 
 # MAC-VRF
 set / network-instance mac-vrf-2 type mac-vrf
 set / network-instance mac-vrf-2 admin-state enable
-set / network-instance mac-vrf-2 vxlan-interface vxlan1.1
+set / network-instance mac-vrf-2 vxlan-interface vxlan1.34
 set / network-instance mac-vrf-2 interface lag1.34
 set / network-instance mac-vrf-2 interface irb0.34
 set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1
 set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 admin-state enable
-set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.1
+set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.34
 set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 evi 34
-set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 ecmp 2
-set / network-instance mac-vrf-2 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:2
-set / network-instance mac-vrf-2 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:2
+set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 ecmp 8
+set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 routes bridge-table mac-ip advertise-arp-nd-only-with-mac-table-entry true
+set / network-instance mac-vrf-2 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:34
+set / network-instance mac-vrf-2 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:34
+set / network-instance mac-vrf-2 bridge-table mac-learning admin-state enable
+set / network-instance mac-vrf-2 bridge-table mac-learning aging admin-state enable
+set / network-instance mac-vrf-2 bridge-table mac-learning aging age-time 300
+set / network-instance mac-vrf-2 bridge-table mac-duplication admin-state enable
+set / network-instance mac-vrf-2 bridge-table mac-duplication monitoring-window 3
+set / network-instance mac-vrf-2 bridge-table mac-duplication num-moves 5
+set / network-instance mac-vrf-2 bridge-table mac-duplication hold-down-time 9
+set / network-instance mac-vrf-2 bridge-table mac-duplication action stop-learning
 
 # IP-VRF
 set / network-instance tenant-2 type ip-vrf
@@ -98,14 +110,63 @@ set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1
 set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 admin-state enable
 set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.2
 set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 evi 2
-set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 ecmp 2
+set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 ecmp 8
+set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 routes route-table mac-ip advertise-gateway-mac true
 set / network-instance tenant-2 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:2
 set / network-instance tenant-2 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:2
 
 # VXLAN tunnel interface for MAC-VRF
-set / tunnel-interface vxlan1 vxlan-interface 1 type bridged
-set / tunnel-interface vxlan1 vxlan-interface 1 ingress vni 1
+set / tunnel-interface vxlan1 vxlan-interface 34 type bridged
+set / tunnel-interface vxlan1 vxlan-interface 34 ingress vni 34
 
 # VXLAN tunnel interface for IP-VRF
 set / tunnel-interface vxlan1 vxlan-interface 2 type routed
 set / tunnel-interface vxlan1 vxlan-interface 2 ingress vni 2
+
+# Routing policies for eBGP
+set / routing-policy prefix-set prefixset-dc1 prefix 10.0.250.0/24 mask-length-range 32..32
+set / routing-policy policy ebgp-isl-export-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match prefix prefix-set prefixset-dc1
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match protocol local
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 match protocol bgp
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 match protocol aggregate
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 match protocol bgp
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action bgp local-preference set 100

--- a/configs/leaf4.cfg
+++ b/configs/leaf4.cfg
@@ -47,47 +47,59 @@ set / network-instance default interface ethernet-1/8.0
 set / network-instance default interface ethernet-1/9.0
 set / network-instance default interface system0.0
 
-# routing policy
-set / routing-policy policy all default-action
-set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols bgp autonomous-system 65104
 set / network-instance default protocols bgp router-id 10.0.250.14
+set / network-instance default protocols bgp ebgp-default-policy import-reject-all true
+set / network-instance default protocols bgp ebgp-default-policy export-reject-all true
+set / network-instance default protocols bgp afi-safi evpn admin-state enable
+set / network-instance default protocols bgp afi-safi evpn multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi evpn multipath ebgp maximum-paths 64
+set / network-instance default protocols bgp afi-safi evpn evpn inter-as-vpn true
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath ebgp maximum-paths 2
+set / network-instance default protocols bgp afi-safi ipv4-unicast evpn rapid-update true
+set / network-instance default protocols bgp preference ebgp 170
+set / network-instance default protocols bgp preference ibgp 170
+set / network-instance default protocols bgp route-advertisement rapid-withdrawal true
+set / network-instance default protocols bgp route-advertisement wait-for-fib-install false
 
-# eBGP-underlay group
-set / network-instance default protocols bgp group eBGP-underlay export-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay import-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay peer-as 65201
-set / network-instance default protocols bgp neighbor 10.0.1.6 peer-group eBGP-underlay
-set / network-instance default protocols bgp neighbor 10.0.2.6 peer-group eBGP-underlay
-
-# iBGP-overlay group
-set / network-instance default protocols bgp group iBGP-overlay export-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay import-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay peer-as 65100
-set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay local-as as-number 65100
-set / network-instance default protocols bgp neighbor 10.0.250.1 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.1 transport local-address 10.0.250.14
-set / network-instance default protocols bgp neighbor 10.0.250.2 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.2 transport local-address 10.0.250.14
+# eBGP group
+set / network-instance default protocols bgp group eBGP-peers admin-state enable
+set / network-instance default protocols bgp group eBGP-peers export-policy [ ebgp-isl-export-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers import-policy [ ebgp-isl-import-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers failure-detection fast-failover true
+set / network-instance default protocols bgp group eBGP-peers afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group eBGP-peers afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp group eBGP-peers peer-as 65201
+set / network-instance default protocols bgp neighbor 10.0.1.6 peer-group eBGP-peers
+set / network-instance default protocols bgp neighbor 10.0.2.6 peer-group eBGP-peers
 
 # MAC-VRF
 set / network-instance mac-vrf-2 type mac-vrf
 set / network-instance mac-vrf-2 admin-state enable
-set / network-instance mac-vrf-2 vxlan-interface vxlan1.1
+set / network-instance mac-vrf-2 vxlan-interface vxlan1.34
 set / network-instance mac-vrf-2 interface lag1.34
 set / network-instance mac-vrf-2 interface irb0.34
 set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1
 set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 admin-state enable
-set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.1
+set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.34
 set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 evi 34
-set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 ecmp 2
-set / network-instance mac-vrf-2 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:2
-set / network-instance mac-vrf-2 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:2
+set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 ecmp 8
+set / network-instance mac-vrf-2 protocols bgp-evpn bgp-instance 1 routes bridge-table mac-ip advertise-arp-nd-only-with-mac-table-entry true
+set / network-instance mac-vrf-2 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:34
+set / network-instance mac-vrf-2 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:34
+set / network-instance mac-vrf-2 bridge-table mac-learning admin-state enable
+set / network-instance mac-vrf-2 bridge-table mac-learning aging admin-state enable
+set / network-instance mac-vrf-2 bridge-table mac-learning aging age-time 300
+set / network-instance mac-vrf-2 bridge-table mac-duplication admin-state enable
+set / network-instance mac-vrf-2 bridge-table mac-duplication monitoring-window 3
+set / network-instance mac-vrf-2 bridge-table mac-duplication num-moves 5
+set / network-instance mac-vrf-2 bridge-table mac-duplication hold-down-time 9
+set / network-instance mac-vrf-2 bridge-table mac-duplication action stop-learning
 
 # IP-VRF
 set / network-instance tenant-2 type ip-vrf
@@ -98,14 +110,63 @@ set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1
 set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 admin-state enable
 set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.2
 set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 evi 2
-set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 ecmp 2
+set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 ecmp 8
+set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 routes route-table mac-ip advertise-gateway-mac true
 set / network-instance tenant-2 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:2
 set / network-instance tenant-2 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:2
 
 # VXLAN tunnel interface for MAC-VRF
-set / tunnel-interface vxlan1 vxlan-interface 1 type bridged
-set / tunnel-interface vxlan1 vxlan-interface 1 ingress vni 1
+set / tunnel-interface vxlan1 vxlan-interface 34 type bridged
+set / tunnel-interface vxlan1 vxlan-interface 34 ingress vni 34
 
 # VXLAN tunnel interface for IP-VRF
 set / tunnel-interface vxlan1 vxlan-interface 2 type routed
 set / tunnel-interface vxlan1 vxlan-interface 2 ingress vni 2
+
+# Routing policies for eBGP
+set / routing-policy prefix-set prefixset-dc1 prefix 10.0.250.0/24 mask-length-range 32..32
+set / routing-policy policy ebgp-isl-export-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match prefix prefix-set prefixset-dc1
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match protocol local
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 match protocol bgp
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 match protocol aggregate
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 match protocol bgp
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action bgp local-preference set 100

--- a/configs/leaf5.cfg
+++ b/configs/leaf5.cfg
@@ -37,33 +37,36 @@ set / network-instance default interface ethernet-1/8.0
 set / network-instance default interface ethernet-1/9.0
 set / network-instance default interface system0.0
 
-# routing policy
-set / routing-policy policy all default-action
-set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols bgp autonomous-system 65105
 set / network-instance default protocols bgp router-id 10.0.250.15
+set / network-instance default protocols bgp ebgp-default-policy import-reject-all true
+set / network-instance default protocols bgp ebgp-default-policy export-reject-all true
+set / network-instance default protocols bgp afi-safi evpn admin-state enable
+set / network-instance default protocols bgp afi-safi evpn multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi evpn multipath ebgp maximum-paths 64
+set / network-instance default protocols bgp afi-safi evpn evpn inter-as-vpn true
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath ebgp maximum-paths 2
+set / network-instance default protocols bgp afi-safi ipv4-unicast evpn rapid-update true
+set / network-instance default protocols bgp preference ebgp 170
+set / network-instance default protocols bgp preference ibgp 170
+set / network-instance default protocols bgp route-advertisement rapid-withdrawal true
+set / network-instance default protocols bgp route-advertisement wait-for-fib-install false
 
-# eBGP-underlay group
-set / network-instance default protocols bgp group eBGP-underlay export-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay import-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay peer-as 65201
-set / network-instance default protocols bgp neighbor 10.0.1.8 peer-group eBGP-underlay
-set / network-instance default protocols bgp neighbor 10.0.2.8 peer-group eBGP-underlay
-
-# iBGP-overlay group
-set / network-instance default protocols bgp group iBGP-overlay export-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay import-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay peer-as 65100
-set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay local-as as-number 65100
-set / network-instance default protocols bgp neighbor 10.0.250.1 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.1 transport local-address 10.0.250.15
-set / network-instance default protocols bgp neighbor 10.0.250.2 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.2 transport local-address 10.0.250.15
+# eBGP group
+set / network-instance default protocols bgp group eBGP-peers admin-state enable
+set / network-instance default protocols bgp group eBGP-peers export-policy [ ebgp-isl-export-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers import-policy [ ebgp-isl-import-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers failure-detection fast-failover true
+set / network-instance default protocols bgp group eBGP-peers afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group eBGP-peers afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp group eBGP-peers peer-as 65201
+set / network-instance default protocols bgp neighbor 10.0.1.8 peer-group eBGP-peers
+set / network-instance default protocols bgp neighbor 10.0.2.8 peer-group eBGP-peers
 
 # MAC-VRF
 set / network-instance mac-vrf-1 type mac-vrf
@@ -74,10 +77,67 @@ set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1
 set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 admin-state enable
 set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.1
 set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 evi 111
-set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 ecmp 2
+set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 ecmp 8
+set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 routes bridge-table mac-ip advertise-arp-nd-only-with-mac-table-entry true
 set / network-instance mac-vrf-1 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:111
 set / network-instance mac-vrf-1 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:111
+set / network-instance mac-vrf-1 bridge-table mac-learning admin-state enable
+set / network-instance mac-vrf-1 bridge-table mac-learning aging admin-state enable
+set / network-instance mac-vrf-1 bridge-table mac-learning aging age-time 300
+set / network-instance mac-vrf-1 bridge-table mac-duplication admin-state enable
+set / network-instance mac-vrf-1 bridge-table mac-duplication monitoring-window 3
+set / network-instance mac-vrf-1 bridge-table mac-duplication num-moves 5
+set / network-instance mac-vrf-1 bridge-table mac-duplication hold-down-time 9
+set / network-instance mac-vrf-1 bridge-table mac-duplication action stop-learning
 
 # VXLAN tunnel interface
 set / tunnel-interface vxlan1 vxlan-interface 1 type bridged
 set / tunnel-interface vxlan1 vxlan-interface 1 ingress vni 1
+
+# Routing policies for eBGP
+set / routing-policy prefix-set prefixset-dc1 prefix 10.0.250.0/24 mask-length-range 32..32
+set / routing-policy policy ebgp-isl-export-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match prefix prefix-set prefixset-dc1
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match protocol local
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 match protocol bgp
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 match protocol aggregate
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 match protocol bgp
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action bgp local-preference set 100

--- a/configs/leaf6.cfg
+++ b/configs/leaf6.cfg
@@ -37,33 +37,36 @@ set / network-instance default interface ethernet-1/8.0
 set / network-instance default interface ethernet-1/9.0
 set / network-instance default interface system0.0
 
-# routing policy
-set / routing-policy policy all default-action
-set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols bgp autonomous-system 65106
 set / network-instance default protocols bgp router-id 10.0.250.16
+set / network-instance default protocols bgp ebgp-default-policy import-reject-all true
+set / network-instance default protocols bgp ebgp-default-policy export-reject-all true
+set / network-instance default protocols bgp afi-safi evpn admin-state enable
+set / network-instance default protocols bgp afi-safi evpn multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi evpn multipath ebgp maximum-paths 64
+set / network-instance default protocols bgp afi-safi evpn evpn inter-as-vpn true
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath ebgp maximum-paths 2
+set / network-instance default protocols bgp afi-safi ipv4-unicast evpn rapid-update true
+set / network-instance default protocols bgp preference ebgp 170
+set / network-instance default protocols bgp preference ibgp 170
+set / network-instance default protocols bgp route-advertisement rapid-withdrawal true
+set / network-instance default protocols bgp route-advertisement wait-for-fib-install false
 
-# eBGP-underlay group
-set / network-instance default protocols bgp group eBGP-underlay export-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay import-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay peer-as 65201
-set / network-instance default protocols bgp neighbor 10.0.1.10 peer-group eBGP-underlay
-set / network-instance default protocols bgp neighbor 10.0.2.10 peer-group eBGP-underlay
-
-# iBGP-overlay group
-set / network-instance default protocols bgp group iBGP-overlay export-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay import-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay peer-as 65100
-set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay local-as as-number 65100
-set / network-instance default protocols bgp neighbor 10.0.250.1 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.1 transport local-address 10.0.250.16
-set / network-instance default protocols bgp neighbor 10.0.250.2 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.2 transport local-address 10.0.250.16
+# eBGP group
+set / network-instance default protocols bgp group eBGP-peers admin-state enable
+set / network-instance default protocols bgp group eBGP-peers export-policy [ ebgp-isl-export-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers import-policy [ ebgp-isl-import-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers failure-detection fast-failover true
+set / network-instance default protocols bgp group eBGP-peers afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group eBGP-peers afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp group eBGP-peers peer-as 65201
+set / network-instance default protocols bgp neighbor 10.0.1.10 peer-group eBGP-peers
+set / network-instance default protocols bgp neighbor 10.0.2.10 peer-group eBGP-peers
 
 # MAC-VRF
 set / network-instance mac-vrf-1 type mac-vrf
@@ -74,10 +77,67 @@ set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1
 set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 admin-state enable
 set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.1
 set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 evi 111
-set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 ecmp 2
+set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 ecmp 8
+set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 routes bridge-table mac-ip advertise-arp-nd-only-with-mac-table-entry true
 set / network-instance mac-vrf-1 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:111
 set / network-instance mac-vrf-1 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:111
+set / network-instance mac-vrf-1 bridge-table mac-learning admin-state enable
+set / network-instance mac-vrf-1 bridge-table mac-learning aging admin-state enable
+set / network-instance mac-vrf-1 bridge-table mac-learning aging age-time 300
+set / network-instance mac-vrf-1 bridge-table mac-duplication admin-state enable
+set / network-instance mac-vrf-1 bridge-table mac-duplication monitoring-window 3
+set / network-instance mac-vrf-1 bridge-table mac-duplication num-moves 5
+set / network-instance mac-vrf-1 bridge-table mac-duplication hold-down-time 9
+set / network-instance mac-vrf-1 bridge-table mac-duplication action stop-learning
 
 # VXLAN tunnel interface
 set / tunnel-interface vxlan1 vxlan-interface 1 type bridged
 set / tunnel-interface vxlan1 vxlan-interface 1 ingress vni 1
+
+# Routing policies for eBGP
+set / routing-policy prefix-set prefixset-dc1 prefix 10.0.250.0/24 mask-length-range 32..32
+set / routing-policy policy ebgp-isl-export-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match prefix prefix-set prefixset-dc1
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match protocol local
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 match protocol bgp
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 match protocol aggregate
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 match protocol bgp
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action bgp local-preference set 100

--- a/configs/leaf7.cfg
+++ b/configs/leaf7.cfg
@@ -47,47 +47,59 @@ set / network-instance default interface ethernet-1/8.0
 set / network-instance default interface ethernet-1/9.0
 set / network-instance default interface system0.0
 
-# routing policy
-set / routing-policy policy all default-action
-set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols bgp autonomous-system 65107
 set / network-instance default protocols bgp router-id 10.0.250.17
+set / network-instance default protocols bgp ebgp-default-policy import-reject-all true
+set / network-instance default protocols bgp ebgp-default-policy export-reject-all true
+set / network-instance default protocols bgp afi-safi evpn admin-state enable
+set / network-instance default protocols bgp afi-safi evpn multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi evpn multipath ebgp maximum-paths 64
+set / network-instance default protocols bgp afi-safi evpn evpn inter-as-vpn true
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath ebgp maximum-paths 2
+set / network-instance default protocols bgp afi-safi ipv4-unicast evpn rapid-update true
+set / network-instance default protocols bgp preference ebgp 170
+set / network-instance default protocols bgp preference ibgp 170
+set / network-instance default protocols bgp route-advertisement rapid-withdrawal true
+set / network-instance default protocols bgp route-advertisement wait-for-fib-install false
 
-# eBGP-underlay group
-set / network-instance default protocols bgp group eBGP-underlay export-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay import-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay peer-as 65201
-set / network-instance default protocols bgp neighbor 10.0.1.12 peer-group eBGP-underlay
-set / network-instance default protocols bgp neighbor 10.0.2.12 peer-group eBGP-underlay
-
-# iBGP-overlay group
-set / network-instance default protocols bgp group iBGP-overlay export-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay import-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay peer-as 65100
-set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay local-as as-number 65100
-set / network-instance default protocols bgp neighbor 10.0.250.1 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.1 transport local-address 10.0.250.17
-set / network-instance default protocols bgp neighbor 10.0.250.2 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.2 transport local-address 10.0.250.17
+# eBGP group
+set / network-instance default protocols bgp group eBGP-peers admin-state enable
+set / network-instance default protocols bgp group eBGP-peers export-policy [ ebgp-isl-export-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers import-policy [ ebgp-isl-import-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers failure-detection fast-failover true
+set / network-instance default protocols bgp group eBGP-peers afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group eBGP-peers afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp group eBGP-peers peer-as 65201
+set / network-instance default protocols bgp neighbor 10.0.1.12 peer-group eBGP-peers
+set / network-instance default protocols bgp neighbor 10.0.2.12 peer-group eBGP-peers
 
 # MAC-VRF
 set / network-instance mac-vrf-4 type mac-vrf
 set / network-instance mac-vrf-4 admin-state enable
-set / network-instance mac-vrf-4 vxlan-interface vxlan1.1
+set / network-instance mac-vrf-4 vxlan-interface vxlan1.78
 set / network-instance mac-vrf-4 interface lag1.78
 set / network-instance mac-vrf-4 interface irb0.78
 set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1
 set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1 admin-state enable
-set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.1
+set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.78
 set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1 evi 78
-set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1 ecmp 2
-set / network-instance mac-vrf-4 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:2
-set / network-instance mac-vrf-4 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:2
+set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1 ecmp 8
+set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1 routes bridge-table mac-ip advertise-arp-nd-only-with-mac-table-entry true
+set / network-instance mac-vrf-4 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:78
+set / network-instance mac-vrf-4 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:78
+set / network-instance mac-vrf-4 bridge-table mac-learning admin-state enable
+set / network-instance mac-vrf-4 bridge-table mac-learning aging admin-state enable
+set / network-instance mac-vrf-4 bridge-table mac-learning aging age-time 300
+set / network-instance mac-vrf-4 bridge-table mac-duplication admin-state enable
+set / network-instance mac-vrf-4 bridge-table mac-duplication monitoring-window 3
+set / network-instance mac-vrf-4 bridge-table mac-duplication num-moves 5
+set / network-instance mac-vrf-4 bridge-table mac-duplication hold-down-time 9
+set / network-instance mac-vrf-4 bridge-table mac-duplication action stop-learning
 
 # IP-VRF
 set / network-instance tenant-2 type ip-vrf
@@ -98,14 +110,63 @@ set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1
 set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 admin-state enable
 set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.2
 set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 evi 2
-set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 ecmp 2
+set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 ecmp 8
+set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 routes route-table mac-ip advertise-gateway-mac true
 set / network-instance tenant-2 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:2
 set / network-instance tenant-2 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:2
 
 # VXLAN tunnel interface for MAC-VRF
-set / tunnel-interface vxlan1 vxlan-interface 1 type bridged
-set / tunnel-interface vxlan1 vxlan-interface 1 ingress vni 1
+set / tunnel-interface vxlan1 vxlan-interface 78 type bridged
+set / tunnel-interface vxlan1 vxlan-interface 78 ingress vni 78
 
 # VXLAN tunnel interface for IP-VRF
 set / tunnel-interface vxlan1 vxlan-interface 2 type routed
 set / tunnel-interface vxlan1 vxlan-interface 2 ingress vni 2
+
+# Routing policies for eBGP
+set / routing-policy prefix-set prefixset-dc1 prefix 10.0.250.0/24 mask-length-range 32..32
+set / routing-policy policy ebgp-isl-export-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match prefix prefix-set prefixset-dc1
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match protocol local
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 match protocol bgp
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 match protocol aggregate
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 match protocol bgp
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action bgp local-preference set 100

--- a/configs/leaf8.cfg
+++ b/configs/leaf8.cfg
@@ -47,47 +47,59 @@ set / network-instance default interface ethernet-1/8.0
 set / network-instance default interface ethernet-1/9.0
 set / network-instance default interface system0.0
 
-# routing policy
-set / routing-policy policy all default-action
-set / routing-policy policy all default-action policy-result accept
 
 # BGP configuration
 set / network-instance default protocols bgp autonomous-system 65108
 set / network-instance default protocols bgp router-id 10.0.250.18
+set / network-instance default protocols bgp ebgp-default-policy import-reject-all true
+set / network-instance default protocols bgp ebgp-default-policy export-reject-all true
+set / network-instance default protocols bgp afi-safi evpn admin-state enable
+set / network-instance default protocols bgp afi-safi evpn multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi evpn multipath ebgp maximum-paths 64
+set / network-instance default protocols bgp afi-safi evpn evpn inter-as-vpn true
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath ebgp maximum-paths 2
+set / network-instance default protocols bgp afi-safi ipv4-unicast evpn rapid-update true
+set / network-instance default protocols bgp preference ebgp 170
+set / network-instance default protocols bgp preference ibgp 170
+set / network-instance default protocols bgp route-advertisement rapid-withdrawal true
+set / network-instance default protocols bgp route-advertisement wait-for-fib-install false
 
-# eBGP-underlay group
-set / network-instance default protocols bgp group eBGP-underlay export-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay import-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay peer-as 65201
-set / network-instance default protocols bgp neighbor 10.0.1.14 peer-group eBGP-underlay
-set / network-instance default protocols bgp neighbor 10.0.2.14 peer-group eBGP-underlay
-
-# iBGP-overlay group
-set / network-instance default protocols bgp group iBGP-overlay export-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay import-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay peer-as 65100
-set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay local-as as-number 65100
-set / network-instance default protocols bgp neighbor 10.0.250.1 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.1 transport local-address 10.0.250.18
-set / network-instance default protocols bgp neighbor 10.0.250.2 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.2 transport local-address 10.0.250.18
+# eBGP group
+set / network-instance default protocols bgp group eBGP-peers admin-state enable
+set / network-instance default protocols bgp group eBGP-peers export-policy [ ebgp-isl-export-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers import-policy [ ebgp-isl-import-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers failure-detection fast-failover true
+set / network-instance default protocols bgp group eBGP-peers afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group eBGP-peers afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp group eBGP-peers peer-as 65201
+set / network-instance default protocols bgp neighbor 10.0.1.14 peer-group eBGP-peers
+set / network-instance default protocols bgp neighbor 10.0.2.14 peer-group eBGP-peers
 
 # MAC-VRF
-set / network-instance mac-vrf-1 type mac-vrf
-set / network-instance mac-vrf-1 admin-state enable
-set / network-instance mac-vrf-1 vxlan-interface vxlan1.1
-set / network-instance mac-vrf-1 interface lag1.78
-set / network-instance mac-vrf-1 interface irb0.78
-set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1
-set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 admin-state enable
-set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.1
-set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 evi 78
-set / network-instance mac-vrf-1 protocols bgp-evpn bgp-instance 1 ecmp 2
-set / network-instance mac-vrf-1 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:2
-set / network-instance mac-vrf-1 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:2
+set / network-instance mac-vrf-4 type mac-vrf
+set / network-instance mac-vrf-4 admin-state enable
+set / network-instance mac-vrf-4 vxlan-interface vxlan1.78
+set / network-instance mac-vrf-4 interface lag1.78
+set / network-instance mac-vrf-4 interface irb0.78
+set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1
+set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1 admin-state enable
+set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.78
+set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1 evi 78
+set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1 ecmp 8
+set / network-instance mac-vrf-4 protocols bgp-evpn bgp-instance 1 routes bridge-table mac-ip advertise-arp-nd-only-with-mac-table-entry true
+set / network-instance mac-vrf-4 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:78
+set / network-instance mac-vrf-4 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:78
+set / network-instance mac-vrf-4 bridge-table mac-learning admin-state enable
+set / network-instance mac-vrf-4 bridge-table mac-learning aging admin-state enable
+set / network-instance mac-vrf-4 bridge-table mac-learning aging age-time 300
+set / network-instance mac-vrf-4 bridge-table mac-duplication admin-state enable
+set / network-instance mac-vrf-4 bridge-table mac-duplication monitoring-window 3
+set / network-instance mac-vrf-4 bridge-table mac-duplication num-moves 5
+set / network-instance mac-vrf-4 bridge-table mac-duplication hold-down-time 9
+set / network-instance mac-vrf-4 bridge-table mac-duplication action stop-learning
 
 # IP-VRF
 set / network-instance tenant-2 type ip-vrf
@@ -98,14 +110,63 @@ set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1
 set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 admin-state enable
 set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 vxlan-interface vxlan1.2
 set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 evi 2
-set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 ecmp 2
+set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 ecmp 8
+set / network-instance tenant-2 protocols bgp-evpn bgp-instance 1 routes route-table mac-ip advertise-gateway-mac true
 set / network-instance tenant-2 protocols bgp-vpn bgp-instance 1 route-target export-rt target:65100:2
 set / network-instance tenant-2 protocols bgp-vpn bgp-instance 1 route-target import-rt target:65100:2
 
 # VXLAN tunnel interface for MAC-VRF
-set / tunnel-interface vxlan1 vxlan-interface 1 type bridged
-set / tunnel-interface vxlan1 vxlan-interface 1 ingress vni 1
+set / tunnel-interface vxlan1 vxlan-interface 78 type bridged
+set / tunnel-interface vxlan1 vxlan-interface 78 ingress vni 78
 
 # VXLAN tunnel interface for IP-VRF
 set / tunnel-interface vxlan1 vxlan-interface 2 type routed
 set / tunnel-interface vxlan1 vxlan-interface 2 ingress vni 2
+
+# Routing policies for eBGP
+set / routing-policy prefix-set prefixset-dc1 prefix 10.0.250.0/24 mask-length-range 32..32
+set / routing-policy policy ebgp-isl-export-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match prefix prefix-set prefixset-dc1
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match protocol local
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 match protocol bgp
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 match protocol aggregate
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 match protocol bgp
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action bgp local-preference set 100

--- a/configs/spine1.cfg
+++ b/configs/spine1.cfg
@@ -32,55 +32,94 @@ set / network-instance default interface ethernet-1/7.0
 set / network-instance default interface ethernet-1/8.0
 set / network-instance default interface system0.0
 
-# routing policy
-set / routing-policy policy all default-action
-set / routing-policy policy all default-action policy-result accept
-
 # BGP configuration
 set / network-instance default protocols bgp autonomous-system 65201
 set / network-instance default protocols bgp router-id 10.0.250.1
+set / network-instance default protocols bgp ebgp-default-policy import-reject-all true
+set / network-instance default protocols bgp ebgp-default-policy export-reject-all true
+set / network-instance default protocols bgp afi-safi evpn admin-state enable
+set / network-instance default protocols bgp afi-safi evpn multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi evpn multipath ebgp maximum-paths 64
+set / network-instance default protocols bgp afi-safi evpn evpn inter-as-vpn true
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath ebgp maximum-paths 6
+set / network-instance default protocols bgp afi-safi ipv4-unicast evpn rapid-update true
+set / network-instance default protocols bgp preference ebgp 170
+set / network-instance default protocols bgp preference ibgp 170
+set / network-instance default protocols bgp route-advertisement rapid-withdrawal true
+set / network-instance default protocols bgp route-advertisement wait-for-fib-install false
 
-# Underlay config
-set / network-instance default protocols bgp group eBGP-underlay export-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay import-policy [ all ]
+# eBGP group
+set / network-instance default protocols bgp group eBGP-peers admin-state enable
+set / network-instance default protocols bgp group eBGP-peers export-policy [ ebgp-isl-export-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers import-policy [ ebgp-isl-import-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers failure-detection fast-failover true
+set / network-instance default protocols bgp group eBGP-peers afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group eBGP-peers afi-safi ipv4-unicast admin-state enable
 set / network-instance default protocols bgp neighbor 10.0.1.1 peer-as 65101
-set / network-instance default protocols bgp neighbor 10.0.1.1 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.1.1 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.1.3 peer-as 65102
-set / network-instance default protocols bgp neighbor 10.0.1.3 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.1.3 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.1.5 peer-as 65103
-set / network-instance default protocols bgp neighbor 10.0.1.5 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.1.5 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.1.7 peer-as 65104
-set / network-instance default protocols bgp neighbor 10.0.1.7 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.1.7 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.1.9 peer-as 65105
-set / network-instance default protocols bgp neighbor 10.0.1.9 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.1.9 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.1.11 peer-as 65106
-set / network-instance default protocols bgp neighbor 10.0.1.11 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.1.11 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.1.13 peer-as 65107
-set / network-instance default protocols bgp neighbor 10.0.1.13 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.1.13 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.1.15 peer-as 65108
-set / network-instance default protocols bgp neighbor 10.0.1.15 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.1.15 peer-group eBGP-peers
 
-# Overlay config
-set / network-instance default protocols bgp group iBGP-overlay export-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay import-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay local-as as-number 65100
-set / network-instance default protocols bgp group iBGP-overlay route-reflector client true
-set / network-instance default protocols bgp neighbor 10.0.250.11 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.11 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.12 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.12 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.13 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.13 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.14 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.14 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.15 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.15 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.16 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.16 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.17 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.17 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.18 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.18 peer-group iBGP-overlay
+
+# Routing policies for eBGP
+set / routing-policy prefix-set prefixset-dc1 prefix 10.0.250.0/24 mask-length-range 32..32
+set / routing-policy policy ebgp-isl-export-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match prefix prefix-set prefixset-dc1
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match protocol local
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 match protocol bgp
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 match protocol aggregate
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 match protocol bgp
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action bgp local-preference set 100

--- a/configs/spine2.cfg
+++ b/configs/spine2.cfg
@@ -32,55 +32,94 @@ set / network-instance default interface ethernet-1/7.0
 set / network-instance default interface ethernet-1/8.0
 set / network-instance default interface system0.0
 
-# routing policy
-set / routing-policy policy all default-action
-set / routing-policy policy all default-action policy-result accept
-
 # BGP configuration
 set / network-instance default protocols bgp autonomous-system 65201
 set / network-instance default protocols bgp router-id 10.0.250.2
+set / network-instance default protocols bgp ebgp-default-policy import-reject-all true
+set / network-instance default protocols bgp ebgp-default-policy export-reject-all true
+set / network-instance default protocols bgp afi-safi evpn admin-state enable
+set / network-instance default protocols bgp afi-safi evpn multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi evpn multipath ebgp maximum-paths 64
+set / network-instance default protocols bgp afi-safi evpn evpn inter-as-vpn true
+set / network-instance default protocols bgp afi-safi evpn evpn rapid-update true
 set / network-instance default protocols bgp afi-safi ipv4-unicast admin-state enable
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath allow-multiple-as true
+set / network-instance default protocols bgp afi-safi ipv4-unicast multipath ebgp maximum-paths 6
+set / network-instance default protocols bgp afi-safi ipv4-unicast evpn rapid-update true
+set / network-instance default protocols bgp preference ebgp 170
+set / network-instance default protocols bgp preference ibgp 170
+set / network-instance default protocols bgp route-advertisement rapid-withdrawal true
+set / network-instance default protocols bgp route-advertisement wait-for-fib-install false
 
-# Underlay config
-set / network-instance default protocols bgp group eBGP-underlay export-policy [ all ]
-set / network-instance default protocols bgp group eBGP-underlay import-policy [ all ]
+# eBGP group
+set / network-instance default protocols bgp group eBGP-peers admin-state enable
+set / network-instance default protocols bgp group eBGP-peers export-policy [ ebgp-isl-export-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers import-policy [ ebgp-isl-import-policy-dc1 ]
+set / network-instance default protocols bgp group eBGP-peers failure-detection fast-failover true
+set / network-instance default protocols bgp group eBGP-peers afi-safi evpn admin-state enable
+set / network-instance default protocols bgp group eBGP-peers afi-safi ipv4-unicast admin-state enable
 set / network-instance default protocols bgp neighbor 10.0.2.1 peer-as 65101
-set / network-instance default protocols bgp neighbor 10.0.2.1 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.2.1 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.2.3 peer-as 65102
-set / network-instance default protocols bgp neighbor 10.0.2.3 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.2.3 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.2.5 peer-as 65103
-set / network-instance default protocols bgp neighbor 10.0.2.5 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.2.5 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.2.7 peer-as 65104
-set / network-instance default protocols bgp neighbor 10.0.2.7 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.2.7 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.2.9 peer-as 65105
-set / network-instance default protocols bgp neighbor 10.0.2.9 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.2.9 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.2.11 peer-as 65106
-set / network-instance default protocols bgp neighbor 10.0.2.11 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.2.11 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.2.13 peer-as 65107
-set / network-instance default protocols bgp neighbor 10.0.2.13 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.2.13 peer-group eBGP-peers
 set / network-instance default protocols bgp neighbor 10.0.2.15 peer-as 65108
-set / network-instance default protocols bgp neighbor 10.0.2.15 peer-group eBGP-underlay
+set / network-instance default protocols bgp neighbor 10.0.2.15 peer-group eBGP-peers
 
-# Overlay config
-set / network-instance default protocols bgp group iBGP-overlay export-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay import-policy [ all ]
-set / network-instance default protocols bgp group iBGP-overlay afi-safi evpn admin-state enable
-set / network-instance default protocols bgp group iBGP-overlay afi-safi ipv4-unicast admin-state disable
-set / network-instance default protocols bgp group iBGP-overlay local-as as-number 65100
-set / network-instance default protocols bgp group iBGP-overlay route-reflector client true
-set / network-instance default protocols bgp neighbor 10.0.250.11 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.11 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.12 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.12 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.13 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.13 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.14 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.14 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.15 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.15 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.16 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.16 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.17 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.17 peer-group iBGP-overlay
-set / network-instance default protocols bgp neighbor 10.0.250.18 peer-as 65100
-set / network-instance default protocols bgp neighbor 10.0.250.18 peer-group iBGP-overlay
+
+# Routing policies for eBGP
+set / routing-policy prefix-set prefixset-dc1 prefix 10.0.250.0/24 mask-length-range 32..32
+set / routing-policy policy ebgp-isl-export-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match prefix prefix-set prefixset-dc1
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 match protocol local
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 match protocol bgp
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 15 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 match protocol aggregate
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 20 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-export-policy-dc1 statement 45 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 default-action policy-result reject
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 match protocol bgp
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 10 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 match bgp evpn route-type [ 1 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 25 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 match bgp evpn route-type [ 2 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 30 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 match bgp evpn route-type [ 3 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 35 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 match bgp evpn route-type [ 4 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 40 action bgp local-preference set 100
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 match bgp evpn route-type [ 5 ]
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action policy-result accept
+set / routing-policy policy ebgp-isl-import-policy-dc1 statement 45 action bgp local-preference set 100


### PR DESCRIPTION
I updated the configuration to eBGP-only with IPv4 and EVPN address families in the same session. This matches the Nokia Validated Design. Also added a .gitignore to exclude some Clab artifacts.

Note: I did not enable BFD as it seems unnecessary for the purposes of this lab. That could be added if desired.